### PR TITLE
Conda install where possible

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -5,7 +5,6 @@ dependencies:
   - bokeh=1.0.4
   - dask=1.1.4
   - dask-ml=0.12.0
-  - dask_xgboost
   - distributed=1.26
   - jupyterlab=0.35.1
   - nodejs=8.9
@@ -23,4 +22,5 @@ dependencies:
   - bottleneck
   - py-xgboost
   - pip:
+    - dask_xgboost
     - mimesis

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -5,12 +5,15 @@ dependencies:
   - bokeh=1.0.4
   - dask=1.1.4
   - dask-ml=0.12.0
+  - dask_xgboost
   - distributed=1.26
   - jupyterlab=0.35.1
   - nodejs=8.9
   - numpy
   - pandas
   - pyarrow==0.10.0
+  - python-graphviz
+  - seaborn
   - scikit-learn=0.20
   - matplotlib
   - nbserverproxy
@@ -20,7 +23,4 @@ dependencies:
   - bottleneck
   - py-xgboost
   - pip:
-    - graphviz
-    - dask_xgboost
-    - seaborn
     - mimesis


### PR DESCRIPTION
Conda install dependencies into environment wherever possible.

* `conda install seaborn` (instead of `pip install seaborn`)
* `conda install python-graphviz` (instead of `pip install graphviz`. Using `python-graphviz` instead of just `graphviz` to match the recommendations in the dask docs here: http://docs.dask.org/en/latest/graphviz.html)
